### PR TITLE
Add a release workflow with trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,49 @@
+name: release-pipeline
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - published
+
+jobs:
+  build-package:
+    runs-on: ubuntu-latest
+    permissions:
+      # write attestations and id-token are necessary for attest-build-provenance-github
+      attestations: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: hynek/build-and-inspect-python-package@v2
+        with:
+          # Prove that the packages were built in the context of this workflow.
+          attest-build-provenance-github: true
+
+  publish-package:
+    # Don't publish from forks
+    if: github.repository_owner == 'cutde-org' && github.event_name == 'release' && github.event.action == 'published'
+    # Use the `release` GitHub environment to protect the Trusted Publishing (OIDC)
+    # workflow by requiring signoff from a maintainer.
+    environment: release
+    needs: build-package
+    runs-on: ubuntu-latest
+    permissions:
+      # write id-token is necessary for trusted publishing (OIDC)
+      id-token: write
+    steps:
+      - name: Download Distribution Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          # The build-and-inspect-python-package action invokes upload-artifact.
+          # These are the correct arguments from that action.
+          name: Packages
+          path: dist
+      - name: Publish Package to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # Implicitly attests that the packages were uploaded in the context of this workflow.


### PR DESCRIPTION
Copied from the [same thing](https://github.com/brendanjmeade/celeri/blob/main/.github/workflows/release.yaml) I set up for celeri, changing the branch name from `main` to `master` and changing the owner from `brendanjmeade` to `cutde-org`.

Closes #36