### PR TITLE
Fix spurious warning about Fortran ordering

### DIFF
--- a/cutde/coordinators.py
+++ b/cutde/coordinators.py
@@ -73,9 +73,9 @@ def solve_types(obs_pts, tris, slips):
             )
             out_arr = out_arr.astype(float_type)
 
-        if out_arr.flags.f_contiguous:
+        if not out_arr.flags.c_contiguous:
             warnings.warn(
-                f"The {name} input array has Fortran ordering. "
+                f"The {name} input array is not C-contiguous. "
                 "Converting to C ordering. This may be expensive."
             )
             out_arr = np.ascontiguousarray(out_arr)


### PR DESCRIPTION
This warning is trying to ensure C-contiguity of the input. However, F-contiguity and C-contiguity are neither exclusive nor comprehensive. It's better to simply check directly if the array is C-contiguous.

Example when a dimension has length 1 so that an array is simultaneously F- and C-contiguous, and would lead to a spurious warning:

```python
m = np.array([[1, 2]])
assert m.flags.c_contiguous and m.flags.f_contiguous
```