### PR TITLE
Migrate from `master` to `main` branch

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -3,7 +3,7 @@ name: Build and Release Pipeline
 on: 
   push:
     branches:
-      - master
+      - main
   pull_request:
   release:
     types:


### PR DESCRIPTION
Update GitHub workflows to reference main branch in preparation for migration