### PR TITLE
Skip musllinux builds for Python 3.8 on PRs

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -95,6 +95,8 @@ jobs:
           # On PR: only build extremal Python versions (3.8 and 3.13)
           # On main/release: build all supported versions (default behavior)
           CIBW_BUILD: ${{ github.event_name == 'pull_request' && 'cp38-* cp313-*' || '' }}
+          # On PR: skip cp38 musllinux builds (they take ~6 minutes)
+          CIBW_SKIP: ${{ github.event_name == 'pull_request' && 'cp38-musllinux*' || '' }}
 
       - name: Generate build provenance attestations for wheels
         # Only generate attestations for trusted workflows (not fork PRs)


### PR DESCRIPTION
They take too long